### PR TITLE
Calculate hours from duration (HH:MM:SS)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ Usage:
   * Date
   * Jira issue key
   * Description of the worklog
-  * Time spent
+  * Time spent (in `HH:MM:SS` format)
   
 * Adjust column numbers manually in script.
 

--- a/jira-worklog-import.php
+++ b/jira-worklog-import.php
@@ -56,8 +56,10 @@ foreach ($res as $line) {
         $comment  = $line[5];
 
         // Time spent, in decimal value.
-        // TODO: Automatically convert from a H:M:S format to decimal
-        $hours = $line[13];
+        sscanf($line[11], "%d:%d:%d", $hours, $minutes, $seconds);
+        // Round hours to the nearest 15 minutes.
+        // FIXME: Make this rounding configurable.
+        $hours = round(($hours + $minutes / 60 + $seconds / 3600) / 0.25) * 0.25;
 
         // Just debug
         echo "DATE: $date_value TIME: $time_value ISSUE: $issueKey COMMENT: $comment SPENT: $hours\n";


### PR DESCRIPTION
Since Jira doesn't accept time spent values expressed as duration —which is a common format time tracking softwares, such as Toggl use—, those values have to be calculated manually in the CSV/spreadsheet that is used for the import. Let's fix that and have that done automatically by this script.

So this PR is a small addition to extract the decimal value from the `HH:MM:SS` duration. The result will be the number of hours rounded to the nearest 15 minutes. (We should probably make this configurable in the future, but having it hardcoded may be a sensible default for now.)